### PR TITLE
Fix 202-digest-link to digest-link param

### DIFF
--- a/index.html
+++ b/index.html
@@ -563,7 +563,7 @@
       <section id="persistence-fixity">
         <h2>Persistence Fixity</h2>
         <section id="persistence-fixity-preamble" class="informative">
-          <p>In the minimal case, a client that has an original digest value can verify persistence fixity by downloading the LDP-NR and calculating the checksum. To avoid the necessity of transferring a potentially large binary, this specification describes expectation tokens for the <code>Expect</code> header described in [[!RFC2616]]: 202-digest and 202-digest-link</p>
+          <p>In the minimal case, a client that has an original digest value can verify persistence fixity by downloading the LDP-NR and calculating the checksum. To avoid the necessity of transferring a potentially large binary, this specification describes a new expectation token for the <code>Expect</code> header described in [[!RFC2616]]: <code>202-digest</code>, and a <code>digest-link</code> parameter.</p>
 				</section>
         <section id="202-digest">
           <h3>Expect: 202-digest</h3>


### PR DESCRIPTION
[Section 3.3 Persistence Fixity preamble](http://fcrepo.github.io/fcrepo-specification/#persistence-fixity) mentions a  `202-digest-link` token value (only occurrence of that string). Seems that the intention is to have the new `202-digest` token, and then the `digest-link` parameter.

(Perhaps was a left over from an earlier iteration that had two tokens, no parameter?)