### PR TITLE
use more recent RFC7231 instead of RFC2616

### DIFF
--- a/index.html
+++ b/index.html
@@ -566,7 +566,7 @@
       <section id="persistence-fixity">
         <h2>Persistence Fixity</h2>
         <section id="persistence-fixity-preamble" class="informative">
-          <p>In the minimal case, a client that has an original digest value can verify persistence fixity by downloading the LDP-NR and calculating the checksum. To avoid the necessity of transferring a potentially large binary, this specification describes expectation tokens for the <code>Expect</code> header described in [[!RFC2616]]: 202-digest and 202-digest-link</p>
+          <p>In the minimal case, a client that has an original digest value can verify persistence fixity by downloading the LDP-NR and calculating the checksum. To avoid the necessity of transferring a potentially large binary, this specification describes expectation tokens for the <code>Expect</code> header described in [[!RFC7231]]: 202-digest and 202-digest-link</p>
 				</section>
         <section id="202-digest">
           <h3>Expect: 202-digest</h3>


### PR DESCRIPTION
We should be using RFC 7231, particularly [section 5.1.1](https://tools.ietf.org/html/rfc7231#section-5.1.1) instead of the obsolete 2616.