### PR TITLE
remove superfluous statement about content body

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,10 +183,9 @@
         <p>
           When accepting a PUT request against an extant resource, an HTTP <code>Link: rel="type"</code>
           header MAY be included. If that type is a value in the LDP namespace and is not either a
-          current type of the resource or a subtype of a current type of the resource, the request
-          MUST be rejected with a 409 Conflict response containing a corresponding explanatory message
-          in the response body. If the type in the Link header is a subtype of a current type of the
-          resource, and has an interaction model assigned to it by [[LDP]], then the resource MUST
+          current type of the resource or a subtype of a current type of the resource, the request MUST be
+          rejected with a 409 Conflict response. If the type in the Link header is a subtype of a current type
+          of the resource, and has an interaction model assigned to it by [[LDP]], then the resource MUST
           be assigned the new type and the interaction model of the resource MUST be changed to the
           interaction model assigned to the new type by [[LDP]].
         </p>


### PR DESCRIPTION
This removes the text: "containing a corresponding explanatory message in the response body".

Based on LDP 4.2.1.6, such constraints should be defined in a document linked to by a ldp:constrainedBy Link header, and as such defining such constraints in the response body seems unnecessary (certainly unnecessary to call out in the spec IMO).