### PR TITLE
Update URIs for the defined prefer headers

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,11 +248,11 @@
           </p>
           <ul>
             <li>
-              <code>http://fedora.info/definitions/v4/repository#EmbedResources</code>:
+              <code>http://fedora.info/definitions/repository#EmbedResources</code>:
               Requires a server to include representations of any contained resources in the response.
             </li>
             <li>
-              <code>http://fedora.info/definitions/v4/repository#InboundReferences</code>:
+              <code>http://fedora.info/definitions/repository#InboundReferences</code>:
               Requires a server to include triples from any LDP-RS housed in that server that
               feature the requested resource as RDF-object.
             </li>


### PR DESCRIPTION
With the new Fedora ontology added to the repository, this changes the URIs for the prefer headers defined here to align with that ontology.