### PR TITLE
more capitalization changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -571,8 +571,8 @@
           <p>
             This is a non-normative section describing the way the normative specification might be
             applied to implement discoverable versioning patterns. If an implementation of a
-            <a>LDPCv</a> does not support <code>POST</code> to mint versions, that MUST be advertised
-            via <code>OPTIONS</code> as described above. The implementation MAY automatically mint
+            <a>LDPCv</a> does not support <code>POST</code> to mint versions, that must be advertised
+            via <code>OPTIONS</code> as described above. The implementation may automatically mint
             versions instead, but that is outside the requirements of this specification. This
             document specifies normatively only how <a>LDPCv</a>s and <a>LDPRm</a>s can be
             discovered, and how they should act.
@@ -866,7 +866,7 @@
           Non-normative: consumers of these messages should not expect a strict ordering of
           the events reported therein: the fact that a message for Event A is received before
           a message for Event B should not imply that Event A occurred before Event B.
-      Implementations MAY choose to make further guarantees about ordering.
+          Implementations may choose to make further guarantees about ordering.
         </p>
       </section>
 


### PR DESCRIPTION
Some more capitalization changes that were missed earlier. These involve the use of "MAY" and "MUST" in non-normative sections (changing them to their uncapitalized versions).