### PR TITLE
Unsupported Digest types; Resolves #27

### DIFF
--- a/index.html
+++ b/index.html
@@ -197,8 +197,12 @@
           </p>
           <p>
             A HTTP PUT request that includes a <code>Digest</code> header (as described
-            in [[!RFC3230]]) for which the instance-digest in that header does not match
-            the instance it describes, MUST be rejected with a 409 Conflict response.
+            in [[!RFC3230]]) for which any instance-digest in that header does not match the instance
+            it describes, MUST be rejected with a 409 Conflict response.
+          </p>
+          <p>
+            A HTTP PUT/POST request that includes an unsupported <code>Digest</code> type (as described
+            in [[!RFC3230]]), SHOULD be rejected with a 400 Bad Request response.
           </p>
           <p>
             Implementations MUST support <code>Content-Type: message/external-body</code> extensions

--- a/index.html
+++ b/index.html
@@ -164,9 +164,13 @@
         </p>
         <section id="httpPOSTLDPNR">
           <p>
-            A POST request that would create a LDP-NR and includes a <code>Digest</code> header
+            A HTTP POST request that would create a LDP-NR and includes a <code>Digest</code> header
             (as described in [[!RFC3230]]) for which the instance-digest in that header does not
             match that of the new LDP-NR MUST be rejected with a 409 Conflict response.
+          </p>
+          <p>
+            A HTTP POST request that includes an unsupported <code>Digest</code> type (as described
+            in [[!RFC3230]]), SHOULD be rejected with a 400 Bad Request response.
           </p>
           <p>
             Implementations MUST support <code>Content-Type: message/external-body</code> extensions for
@@ -201,7 +205,7 @@
             it describes, MUST be rejected with a 409 Conflict response.
           </p>
           <p>
-            A HTTP PUT/POST request that includes an unsupported <code>Digest</code> type (as described
+            A HTTP PUT request that includes an unsupported <code>Digest</code> type (as described
             in [[!RFC3230]]), SHOULD be rejected with a 400 Bad Request response.
           </p>
           <p>


### PR DESCRIPTION
* Stronger wording indicating a 400 status code
* Use @zimeon's suggested wording to indicate that multiple algorithms can be provided

See: https://github.com/fcrepo/fcrepo-specification/issues/27