### PR TITLE
Use IRI instead of URI

### DIFF
--- a/index.html
+++ b/index.html
@@ -658,17 +658,17 @@
           <h3>Expect: 202-digest</h3>
           <p>
             The <code>202-digest</code> expectation indicates that the client is requesting that
-            the server verify an instance digest for the resource at the request URI.
+            the server verify an instance digest for the resource at the request IRI.
           </p>
           <pre><code>
             Expect                  =  "Expect" ":" 1#digest-expectation
             digest-expectation      = "202-digest" [(digest-param|digest-link-param)]
             digest-param            = ";" #(instance-digest)
-            digest-link-param       = ";" "digest-link" "=" URI-reference
+            digest-link-param       = ";" "digest-link" "=" IRI-reference
           </code></pre>
           <p>
             <code>instance-digest</code> values are of the syntax described in [[!RFC3230]] for the
-            <code>Digest</code> header. <code>URI-reference</code> values for the
+            <code>Digest</code> header. <code>IRI-reference</code> values for the
             <code>digest-link-param</code> are described in [[!RFC2396]].
           </p>
           <p>
@@ -877,7 +877,7 @@
           Emitted events MUST contain exactly one value for each of the following elements:
         </p>
         <ul>
-          <li>Resource Identifier: the URI of the <a>LDPR</a> that was added, changed or removed.</li>
+          <li>Resource Identifier: the IRI of the <a>LDPR</a> that was added, changed or removed.</li>
           <li>Event identifier: a unique identifier for this event.</li>
         </ul>
         <p>


### PR DESCRIPTION
The Fedora specification should support the use internationalized identifiers, and so references to URI should be changed to IRI.

I left the use of `URI-R` and `URI-M` unchanged, as that is the terminology that Memento uses, though I think we should also consider changing those to `IRI-R` and `IRI-M`, respectively.