### PR TITLE
add clarifying statements

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
       <ul>
         <li>
           a reconciliation of [[LDP]] and the well-established version identification and
-          navigation scheme delineated in the [[RFC7089]] specification,
+          navigation scheme delineated in the [[RFC7089]] (Memento) specification,
         </li>
         <li>
           interaction patterns for use with binary fixity information,
@@ -432,7 +432,7 @@
           <p>
             An implementation MUST support <code>GET</code>, as is the case for any <a>LDPR</a>.
             The headers for <code>GET</code> requests and responses on this resource MUST conform
-            to [[!RFC7089]]. Particularly it should be noted that the relevant <a>TimeGate</a> for
+            to [[!RFC7089]] (Memento). Particularly it should be noted that the relevant <a>TimeGate</a> for
             an <a>LDPRm</a> is the original versioned <a>LDPRv</a>.
           </p>
         </section>
@@ -618,7 +618,7 @@
               <a>LDPCv</a>-as-a<a>TimeMap</a> . This pattern is more open to manipulation and could
               be useful for migration from other systems into Fedora implementations. Responses from
               requests to the <a>LDPRv</a> include a <code>Link: rel="timemap"</code> to the same
-              <a>LDPCv</a> as per [[!RFC7089]].
+              <a>LDPCv</a> as per [[!RFC7089]] (Memento).
             </p>
           </section>
         </section>


### PR DESCRIPTION
I don't always remember which RFC is which, and this adds a little bit of clarification with regard to references to the Memento spec.