### PR TITLE
Add missing <section> tag for 3.8.2

### DIFF
--- a/index.html
+++ b/index.html
@@ -507,6 +507,8 @@
             This specification takes no position on the use of <code>message/external-body</code> to create or update
           LDP-RS with ttl or json-ld.
           </p>
+        </section>
+        <section id='proxied-vs-redirected' class='informative'>
           <h4>Proxied Content vs. Redirected Content</h4>
           <p>
             This specification assumes that clients interested in resolving a <code>type='url'</code> or other value


### PR DESCRIPTION
Add missing \<section> tag so that 'Proxied Content vs. Redirected Content' gets a section number 3.8.2. Currently the \<h4> after [3.8.1](https://fcrepo.github.io/fcrepo-specification/#external-content-caveats) has no section number.