### PR TITLE
Tidy memento refs

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@
       <ul>
         <li>
           a reconciliation of [[LDP]] and the well-established version identification and navigation scheme delineated
-        in the [[RFC7089]] (Memento) specification,
+          in the Memento specification [[RFC7089]],
         </li>
         <li>
           interaction patterns for use with binary fixity information,
@@ -180,22 +180,25 @@
         </dd>
         <dt><dfn>URI-R</dfn>:</dt>
         <dd>
-          A type of versioned resource defined in
-          [<a href="https://tools.ietf.org/html/rfc7089#section-1.1">Memento</a>].
+          A type of versioned resource defined in Memento [[RFC7089]]
+          <a href="https://tools.ietf.org/html/rfc7089#section-1.2">section 1.2</a>.
         </dd>
         <dt><dfn>URI-M</dfn>:</dt>
         <dd>
-          A type of resource that is defined in [<a href="https://tools.ietf.org/html/rfc7089#section-1.1">Memento</a>]
+          A type of resource that is defined in Memento [[RFC7089]]
+          <a href="https://tools.ietf.org/html/rfc7089#section-1.2">section 1.2</a>
           as representing a version of a given <a>URI-R</a>.
         </dd>
         <dt><dfn>TimeGate</dfn>:</dt>
         <dd>
-          A type of resource defined in [<a href="https://tools.ietf.org/html/rfc7089#section-1.1">Memento</a>]
+          A type of resource defined in Memento [[RFC7089]]
+          <a href="https://tools.ietf.org/html/rfc7089#section-1.1">section 1.1</a>
           providing <code>Accept-Datetime</code>-varied negotiation of versions of an <a>URI-R</a>.
         </dd>
         <dt><dfn>TimeMap</dfn>:</dt>
         <dd>
-          A type of resource defined in [<a href="https://tools.ietf.org/html/rfc7089#section-1.1">Memento</a>] that
+          A type of resource defined in Memento [[RFC7089]]
+          <a href="https://tools.ietf.org/html/rfc7089#section-1.1">section 1.1</a> that
           contains a machine-readable listing of <a>URI-M</a>s associated to a given <a>URI-R</a>.
         </dd>
       </dl>
@@ -525,8 +528,9 @@
           <h2>General</h2>
           <p>
             A versioned resource for this document provides a <a>TimeGate</a> interaction model as detailed in the
-            Memento specification and indicated by an HTTP header <code>Link: rel="timegate"</code> referencing itself.
-            It otherwise follows the relevant [[!LDP]] specification with the additional behaviors below.
+            Memento specification [[RFC7089]] and indicated by an HTTP header <code>Link: rel="timegate"</code>
+            referencing itself. It otherwise follows the relevant [[!LDP]] specification with the additional
+            behaviors below.
           </p>
         </section>
 
@@ -535,7 +539,8 @@
           <section>
             <h2>Request Headers for an LDPRv</h2>
             <p>
-              <code>Accept-Datetime</code>, exactly as per Memento.
+              <code>Accept-Datetime</code>, exactly as per [[!RFC7089]]
+              <a href='https://tools.ietf.org/html/rfc7089#section-2.1.1'>section 2.1.1</a>.
             </p>
           </section>
 
@@ -546,7 +551,8 @@
               header that indicates that the resource is versioned.
             </p>
             <p>
-              <code>Vary: Accept-Datetime</code>, exactly as per Memento.
+              <code>Vary: Accept-Datetime</code>, exactly as per [[!RFC7089]]
+              <a href='https://tools.ietf.org/html/rfc7089#section-2.1.2'>section 2.1.2</a>.
             </p>
           </section>
         </section>
@@ -566,7 +572,8 @@
           <section>
             <h2>Request Headers for an LDPRv</h2>
             <p>
-              <code>Accept-Datetime</code>, exactly as per Memento.
+              <code>Accept-Datetime</code>, exactly as per [[!RFC7089]]
+              <a href='https://tools.ietf.org/html/rfc7089#section-2.1.1'>section 2.1.1</a>.
             </p>
           </section>
 
@@ -577,7 +584,8 @@
               header that indicates that the resource is versioned.
             </p>
             <p>
-              <code>Vary: Accept-Datetime</code>, exactly as per Memento.
+              <code>Vary: Accept-Datetime</code>, exactly as per [[!RFC7089]]
+              <a href='https://tools.ietf.org/html/rfc7089#section-2.1.2'>section 2.1.2</a>.
             </p>
           </section>
         </section>
@@ -613,7 +621,8 @@
           <h2>HTTP GET</h2>
           <p>
             An implementation MUST support <code>GET</code>, as is the case for any <a>LDPR</a>. The headers for
-            <code>GET</code> requests and responses on this resource MUST conform to [[!RFC7089]] (Memento).
+            <code>GET</code> requests and responses on this resource MUST conform to [[!RFC7089]]
+            <a href='https://tools.ietf.org/html/rfc7089#section-2.1'>section 2.1</a>.
             Particularly it should be noted that the relevant <a>TimeGate</a> for an <a>LDPRm</a> is the original
             versioned <a>LDPRv</a>.
           </p>
@@ -666,8 +675,8 @@
           <p>
             When an <a>LDPR</a> is created with a <code>Link</code> header indicating versioning, a version container
             (<a>LDPCv</a>) is created that contains Memento-identified resources (<a>LDPRm</a>) capturing time-varying
-            representations of the associated <a>LDPR</a>. An <a>LDPCv</a> is both a <a>TimeMap</a> per [[!RFC7089]]
-            (Memento) and an LDP Container. As a <a>TimeMap</a> an <a>LDPCv</a> MUST conform to the specification for
+            representations of the associated <a>LDPR</a>. An <a>LDPCv</a> is both a <a>TimeMap</a> per Memento
+            [[!RFC7089]] and an LDP Container. As a <a>TimeMap</a> an <a>LDPCv</a> MUST conform to the specification for
             such resources in [[!RFC7089]]. An implementation MUST indicate <a>TimeMap</a> in the same way it indicates
             the Container interaction model of the resource via HTTP headers. An <a>LDPCv</a> MUST respond to <code>GET
             Accept: application/link-format</code> as indicated in [[!RFC7089]]
@@ -792,7 +801,7 @@
               <code>POST</code> was made and features in that <a>LDPCv</a>-as-a<a>TimeMap</a>. This pattern is more
               open to manipulation and could be useful for migration from other systems into Fedora implementations.
               Responses from requests to the <a>LDPRv</a> include a <code>Link: rel="timemap"</code> to the same
-              <a>LDPCv</a> as per [[!RFC7089]] (Memento).
+              <a>LDPCv</a> as per [[!RFC7089]] <a href='https://tools.ietf.org/html/rfc7089#section-5'>section 5</a>.
             </p>
           </section>
         </section>


### PR DESCRIPTION
Tidy Memento references to be more consistent. Use forms:

  * "Memento specification \[RFC7089]"  when we refer to the spec in general
  * "Memento \[RFC7089] section x.y" or just " \[RFC7089] section x.y" when we refer to a specific section
  * "Memento" alone refers to a resource that encapsulates a prior state of the Original Resource (not the spec).