### PR TITLE
Clarify checksum calculation in LDP-NR GET requests, ref #148

### DIFF
--- a/index.html
+++ b/index.html
@@ -413,8 +413,9 @@
             header defined in [[!RFC3230]].
           </p>
           <p class='informative'>
-            Non-normative note: Given the use of checksums to validate content integrity, the digest values should be
-            calculated instead of cached.
+            Non-normative note: In the presence of a <code>Want-Digest</code> header, the current <code>Digest</code>
+            value should be calculated to enable fixity verification. Otherwise, it is expected that ETag values may be
+            cached. See <a href="#persistence-fixity"></a>.
           </p>
         </section>
       </section>


### PR DESCRIPTION
Previous language was unclear if checksums were to be calculated at every GET request, as opposed to only when the Want-Digest was provided.