### PR TITLE
Fix informative sections to show status when rendered

### DIFF
--- a/index.html
+++ b/index.html
@@ -298,6 +298,7 @@
             [[!RFC3230]]), SHOULD be rejected with a 400 Bad Request response.
           </p>
           <p class='informative'>
+            Non-normative note:
             Implementations may support <code>Content-Type: message/external-body</code> extensions for request bodies
             for HTTP <code>POST</code> that would create <a>LDP-NR</a>s. This content-type requires a complete
             <code>Content-Type</code> header that includes the location of the external body, e.g <code>Content-Type:
@@ -334,6 +335,7 @@
             [[!RFC3230]]), SHOULD be rejected with a 400 Bad Request response.
           </p>
           <p class='informative'>
+            Non-normative note:
             Implementations may support <code>Content-Type: message/external-body</code> extensions for request bodies
             for HTTP <code>PUT</code> that would create <a>LDP-NR</a>s. This content-type requires a complete
             <code>Content-Type</code> header that includes the location of the external body, e.g <code>Content-Type:
@@ -364,7 +366,7 @@
         <section id="httpPUTcreate" class="informative">
           <h2>Creating resources with HTTP PUT</h2>
           <p>
-            An implementation MAY accept HTTP <code>PUT</code> to create resources ([[!LDP]]
+            An implementation may accept HTTP <code>PUT</code> to create resources ([[!LDP]]
             <a href="https://www.w3.org/TR/ldp/#ldpr-put-create">4.2.4.6</a>). Behavior regarding containment or
             non-containment of resources created with HTTP <code>PUT</code> is not defined by [[!LDP]] or this
             specification.
@@ -681,8 +683,9 @@
             associated <a>LDPRv</a>.
           </p>
           <p class="informative">
-            Non-normative: The <code>application/link-format</code> representation of an <a>LDPCv</a> is not required to
-            include all statements in the <a>LDPCv</a> graph, only those required by <a>TimeMap</a> behaviors.
+            Non-normative note: The <code>application/link-format</code> representation of an <a>LDPCv</a> is not
+            required to include all statements in the <a>LDPCv</a> graph, only those required by <a>TimeMap</a>
+            behaviors.
           </p>
         </section>
 
@@ -750,8 +753,8 @@
 
       </section>
 
-      <section>
-        <h2 class='informative'>Vary</h2>
+      <section class='informative'>
+        <h2>Vary</h2>
         <p>
           When a <code>POST</code> to an <a>LDPCv</a>, or a <code>PUT</code> or <code>PATCH</code> to an <a>LDPRv</a>
           creates a new <a>LDPRm</a>, the response indicates this by using a <code>Vary</code> header as appropriate.


### PR DESCRIPTION
We currently have sections marked informative in the HTML that have the `class='informative'` on the `<p>`, which doesn't then show when rendered. I have fixed this for:

  * Third para of https://fcrepo.github.io/fcrepo-specification/#httpPOSTLDPNR
  * Fourth para of https://fcrepo.github.io/fcrepo-specification/#httpPUTLDPNR
  * Vary section https://fcrepo.github.io/fcrepo-specification/#vary

Also:

  * Un-RFC MAY in non-normative https://fcrepo.github.io/fcrepo-specification/#httpPUTcreate
  * "Non-normative:" -> "Non-normative note:" to be consistent in https://fcrepo.github.io/fcrepo-specification/#general-2