### PR TITLE
Clarify that Fedora = LDP + extra rules in conformance

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,8 +132,8 @@
     <section id="conformance">
       <p>
         A conforming <b>Fedora server</b> is a conforming [[!LDP]] 1.0 server that follows the additional
-	rules defined in sections <a href="#resource-management"></a>, <a href="#resource-versioning"></a>,
-	<a href="#resource-authorization"></a>, and <a href="#notifications"></a> of this specification.
+        rules defined in sections <a href="#resource-management"></a>, <a href="#resource-versioning"></a>,
+        <a href="#resource-authorization"></a>, and <a href="#notifications"></a> of this specification.
       </p>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -131,11 +131,12 @@
 
     <section id="conformance">
       <p>
-        A conforming <b>Fedora server</b> is a conforming [[!LDP]] 1.0 server except where described in this document
-        that also follows the rules defined by Fedora in <a href="#resource-management"></a>,
-        <a href="#resource-versioning"></a>, <a href="#resource-authorization"></a>, and <a href="#notifications"></a>.
+        A conforming <b>Fedora server</b> is a conforming [[!LDP]] 1.0 server that follows the additional
+	rules defined in sections <a href="#resource-management"></a>, <a href="#resource-versioning"></a>,
+	<a href="#resource-authorization"></a>, and <a href="#notifications"></a> of this specification.
       </p>
     </section>
+
     <section id="terminology">
     <h2>Terminology</h2>
     <p>


### PR DESCRIPTION
I think that the current wording in [Conformance](https://fcrepo.github.io/fcrepo-specification/#conformance), especially the *except* is misleading in that it suggests that a Fedora server might not be a fully compliant LDP server:

> A conforming Fedora server is a conforming \[LDP] 1.0 server *except* where described in this document that also follows the rules defined by Fedora in 3. Resource Management, 4. Resource Versioning, 5. Resource Authorization, and 6. Notifications.

This PR changes wording to make it clear that a Fedora server is LDP with extra constraints from the appropriate sections.