### PR TITLE
Do not use ldp: prefix for Link type value

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,9 +216,10 @@
           <h2>LDP-NR creation</h2>
           <p>
             If, in a successful resource creation request, a <code>Link: rel="type"</code> request header specifies the
-            <a>LDP-NR</a> interaction model (<code>ldp:NonRDFSource</code>, regardless of <code>Content-Type:</code>
-            value), then the server SHOULD handle subsequent requests to the newly created resource as if it is an
-            <a>LDP-NR</a>. ([[!LDP]] <a href="https://www.w3.org/TR/ldp/#ldpc-post-createrdf">5.2.3.4 extension</a>)
+            <a>LDP-NR</a> interaction model (<code>http://www.w3.org/ns/ldp#NonRDFSource</code>, regardless of
+            <code>Content-Type:</code> value), then the server SHOULD handle subsequent requests to the newly created resource
+            as if it is an <a>LDP-NR</a>. ([[!LDP]]
+            <a href="https://www.w3.org/TR/ldp/#ldpc-post-createrdf">5.2.3.4 extension</a>)
           </p>
         </section>
         <section id="LDPC">

--- a/index.html
+++ b/index.html
@@ -217,8 +217,8 @@
           <p>
             If, in a successful resource creation request, a <code>Link: rel="type"</code> request header specifies the
             <a>LDP-NR</a> interaction model (<code>http://www.w3.org/ns/ldp#NonRDFSource</code>, regardless of
-            <code>Content-Type:</code> value), then the server SHOULD handle subsequent requests to the newly created resource
-            as if it is an <a>LDP-NR</a>. ([[!LDP]]
+            <code>Content-Type:</code> value), then the server SHOULD handle subsequent requests to the newly created
+            resource as if it is an <a>LDP-NR</a>. ([[!LDP]]
             <a href="https://www.w3.org/TR/ldp/#ldpc-post-createrdf">5.2.3.4 extension</a>)
           </p>
         </section>


### PR DESCRIPTION
... because one has to specify the full URI in the `Link` header