### PR TITLE
Add section on ACL linking on resource creation

### DIFF
--- a/index.html
+++ b/index.html
@@ -925,6 +925,18 @@
           </ul>
         </blockquote>
       </section>
+      <section id="link-acl-on-create">
+        <h2>ACL linking on resource creation</h2>
+        <p>
+          A client HTTP <code>POST</code> or <code>PUT</code> request to create a new <a>LDPR</a> MAY include a
+          <code>Link: rel="acl"</code> header referencing an existing <a>LDP-RS</a> to use as the <a>ACL</a>
+          for the new <a>LDPR</a>. The server MUST respond with a 4xx range status code (e.g. 409 Conflict) if it
+          isn't able to create the <a>LDPR</a> with the specified <a>LDP-RS</a> as the <a>ACL</a>. In that
+          response, the restrictions causing the request to fail MUST be described in a resource indicated by a
+          <code>Link: rel="http://www.w3.org/ns/ldp#constrainedBy"</code> response header, following the pattern of
+          [[!LDP]] <a href='https://www.w3.org/TR/ldp/#ldpr-gen-pubclireqs'>4.2.1.6</a>.
+        <p>
+      </section>
     </section>
 
     <section id="notifications">

--- a/index.html
+++ b/index.html
@@ -930,11 +930,11 @@
         <p>
           A client HTTP <code>POST</code> or <code>PUT</code> request to create a new <a>LDPR</a> MAY include a
           <code>Link: rel="acl"</code> header referencing an existing <a>LDP-RS</a> to use as the <a>ACL</a>
-          for the new <a>LDPR</a>. The server MUST respond with a 4xx range status code (e.g. 409 Conflict) if it
-          isn't able to create the <a>LDPR</a> with the specified <a>LDP-RS</a> as the <a>ACL</a>. In that
-          response, the restrictions causing the request to fail MUST be described in a resource indicated by a
-          <code>Link: rel="http://www.w3.org/ns/ldp#constrainedBy"</code> response header, following the pattern of
-          [[!LDP]] <a href='https://www.w3.org/TR/ldp/#ldpr-gen-pubclireqs'>4.2.1.6</a>.
+          for the new <a>LDPR</a>. The server MUST reject the request and respond with a 4xx or 5xx range status
+          code (e.g. 409 Conflict) if it isn't able to create the <a>LDPR</a> with the specified <a>LDP-RS</a> as
+          the <a>ACL</a>. In that response, the restrictions causing the request to fail MUST be described in a
+          resource indicated by a <code>Link: rel="http://www.w3.org/ns/ldp#constrainedBy"</code> response header,
+          following the pattern of [[!LDP]] <a href='https://www.w3.org/TR/ldp/#ldpr-gen-pubclireqs'>4.2.1.6</a>.
         <p>
       </section>
     </section>


### PR DESCRIPTION
Fixes #176.

Adds a section "ACL linking on resource creation" based on https://github.com/fcrepo/fcrepo-specification/issues/176#issuecomment-319149546 . This places a requirement on servers to recognize the `Link: rel="acl"` header on resource creation, whether or not they support specification of an ACL in this way. If they don't support it, response will always be 4xx. It does not preclude other ways of linking a resource to an ACL.