### PR TITLE
Fix typo: add missing hyphen

### DIFF
--- a/index.html
+++ b/index.html
@@ -843,7 +843,7 @@
             Non-normative note:
             An <a>LDPRm</a> for a particular <a>LDPRv</a> is created on <code>POST</code> to any <a>LDPCv</a>
             associated with that <a>LDPRv</a>. The new <a>LDPRm</a> is contained in the <a>LDPCv</a> to which the
-            <code>POST</code> was made and features in that <a>LDPCv</a>-as-a<a>TimeMap</a>. This pattern is more
+            <code>POST</code> was made and features in that <a>LDPCv</a>-as-a-<a>TimeMap</a>. This pattern is more
             open to manipulation and could be useful for migration from other systems into Fedora implementations.
             Responses from requests to the <a>LDPRv</a> include a <code>Link: rel="timemap"</code> to the same
             <a>LDPCv</a> as per [[!RFC7089]] <a href='https://tools.ietf.org/html/rfc7089#section-5'>section 5</a>.


### PR DESCRIPTION
Trivial typo fix (one character)