### PR TITLE
Torching Depth header in lieu of advertising recursive DELETEs 

### DIFF
--- a/index.html
+++ b/index.html
@@ -497,7 +497,14 @@
             resources.
           </p>
           <p>
-            An implementation that cannot recurse MUST NOT advertise <code>DELETE</code> in response to OPTIONS
+            An implementation MUST NOT return a 200 or 204 response unless the entire operation successfully completed.
+          </p>
+          <p>
+            An implementation MUST NOT emit a message that implies the successful DELETE of a resource until the
+            resource has been successfully removed.
+          </p>
+          <p>
+            An implementation that cannot recurse SHOULD NOT advertise <code>DELETE</code> in response to OPTIONS
             requests for containers with contained resources.
           </p>
           <blockquote id="httpDELETEatomicity" class="informative">

--- a/index.html
+++ b/index.html
@@ -492,7 +492,15 @@
         <section id="httpDELETERecursion">
           <h3>Recursive Delete</h3>
           <p>
-            If a server supports <code>DELETE</code>, its recursion MUST be reckoned along the [[!LDP]]
+            An implementation that cannot recurse SHOULD NOT advertise <code>DELETE</code> in response to OPTIONS
+            requests for containers with contained resources.
+          </p>
+          <blockquote id="http-delete-recursion-info" class="informative">
+            Non-normative note: Clients should assume from an advertised DELETE that they do not need to look for
+            contained/child resources to clean up.
+          </blockquote>
+          <p>
+            If a server supports <code>DELETE</code>, any recursion MUST be reckoned along the [[!LDP]]
             <a href="https://www.w3.org/TR/ldp/#dfn-containment">containment relationships</a> linking contained
             resources.
           </p>
@@ -502,10 +510,6 @@
           <p>
             An implementation MUST NOT emit a message that implies the successful DELETE of a resource until the
             resource has been successfully removed.
-          </p>
-          <p>
-            An implementation that cannot recurse SHOULD NOT advertise <code>DELETE</code> in response to OPTIONS
-            requests for containers with contained resources.
           </p>
           <blockquote id="httpDELETEatomicity" class="informative">
             Non-normative note: Atomicity is not guaranteed for HTTP <code>DELETE</code> requests that affect multiple

--- a/index.html
+++ b/index.html
@@ -489,19 +489,16 @@
           <a href='https://www.w3.org/TR/ldp/#ldpc-HTTP_DELETE'>section 5.2.5</a>, it must also follow the additional
           behavior outlined below.
         </p>
-        <section id="httpDELETEDepth">
-          <h3>Depth Header</h3>
+        <section id="httpDELETERecursion">
+          <h3>Recursive Delete</h3>
           <p>
-            A Fedora server MUST support the <code>Depth</code> header, as defined in [[!RFC4918]]
-            <a href='https://tools.ietf.org/html/rfc4918#section-10.2'> section 10.2 </a>. Implementations MAY choose
-            not to support all of the header's values and MUST reject a request containing an unsupported
-            <code>Depth</code> value with a 400 (Bad Request). The default value for the <code>Depth</code> header if
-            not present in a request is left up to the implementer.
-          </p>
-          <p>
-            If a server supports recursive <code>DELETE</code>, that recursion MUST be reckoned along the [[!LDP]]
+            If a server supports <code>DELETE</code>, its recursion MUST be reckoned along the [[!LDP]]
             <a href="https://www.w3.org/TR/ldp/#dfn-containment">containment relationships</a> linking contained
             resources.
+          </p>
+          <p>
+            An implementation that cannot recurse MUST NOT advertise <code>DELETE</code> in response to OPTIONS
+            requests for containers with contained resources.
           </p>
           <blockquote id="httpDELETEatomicity" class="informative">
             Non-normative note: Atomicity is not guaranteed for HTTP <code>DELETE</code> requests that affect multiple


### PR DESCRIPTION
Resolves #234

This PR's intention is to remove the Depth header, which has proven confusing, and to replace it by:
* Making sure DELETEs are recursive along the lines of containment
* Allowing implementations that do not want to provide recursive DELETEs by forbidding advertising DELETE in OPTIONS responses for containers with children.
