### PR TITLE
Datetime negotiation should redirect to the LDPRm

### DIFF
--- a/index.html
+++ b/index.html
@@ -616,28 +616,22 @@
 
         <section id="LDPRv-get">
           <h2>HTTP GET</h2>
-          <section id="LDPRv-get-request">
-            <h2>Request Headers for an LDPRv</h2>
-            <p>
-              The <code>Accept-Datetime</code> header is used to request a past state, exactly as per [[!RFC7089]]
-              <a href='https://tools.ietf.org/html/rfc7089#section-2.1.1'>section 2.1.1</a>.
-            </p>
-          </section>
-
-          <section id="LDPRv-get-response">
-            <h2>Response Headers</h2>
-            <p>
-              The response to a GET request on an <a>LDPRv</a> MUST include a <code>Link: rel="original timegate"</code>
-              header referencing itself, and at least one <code>Link: rel="timemap"</code> header referencing an
-              associated <a>LDPCv</a>. It is the presence of these headers that indicates that the resource is
-              versioned.
-            </p>
-            <p>
-              The response to a GET request on an <a>LDPRv</a> MUST include a <code>Vary: Accept-Datetime</code>
-              header, exactly as per [[!RFC7089]]
-              <a href='https://tools.ietf.org/html/rfc7089#section-2.1.2'>section 2.1.2</a>.
-            </p>
-          </section>
+          <p>
+            The <code>Accept-Datetime</code> header is used to request a past state, exactly as per [[!RFC7089]]
+            <a href='https://tools.ietf.org/html/rfc7089#section-2.1.1'>section 2.1.1</a>. A successful response
+            MUST be a 302 (Found) redirect to the appropriate <a>LDPRm</a>.
+          </p>
+          <p>
+            The response to a GET request on an <a>LDPRv</a> MUST include a <code>Link: rel="original timegate"</code>
+            header referencing itself, and at least one <code>Link: rel="timemap"</code> header referencing an
+            associated <a>LDPCv</a>. It is the presence of these headers that indicates that the resource is
+            versioned.
+          </p>
+          <p>
+            The response to a GET request on an <a>LDPRv</a> MUST include a <code>Vary: Accept-Datetime</code>
+            header, exactly as per [[!RFC7089]]
+            <a href='https://tools.ietf.org/html/rfc7089#section-2.1.2'>section 2.1.2</a>.
+          </p>
         </section>
 
         <section id="LDPRv-put">


### PR DESCRIPTION
* Explicitly require 302 (Found) redirection upon successful Datetime negotiation
* Flatten overly-nested section

Fixes #258 