### PR TITLE
Remove General headings from versioning to be consistent with rest of spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -665,11 +665,7 @@
       <section id="LDPRm">
         <h2>Version Resources (<a>LDPRm</a>)</h2>
         <p>
-          When an <a>LDPR</a> is created with a <code>Link: rel="type"</code> header
-          specifying type <code>http://mementoweb.org/ns#OriginalResource</code>
-          to indicate versioning, it is created as both an <a>LDPRv</a> and a Memento: an
-          <a>LDPRm</a>. An <a>LDPRm</a> MAY be deleted; however,
-          it MUST NOT be modified once created.
+          An <a>LDPRm</a> MAY be deleted; however, it MUST NOT be modified once created.
         </p>
 
         <section id="LDPRm-delete">
@@ -727,17 +723,10 @@
       <section id="LDPCv">
         <h2>Version Containers (<a>LDPCv</a>)</h2>
         <p>
-          When an <a>LDPR</a> is created with a <code>Link: rel="type"</code> header
-          specifying type <code>http://mementoweb.org/ns#OriginalResource</code>
-          to indicate versioning, a version container
-          (<a>LDPCv</a>) MUST be created that contains Memento-identified resources (<a>LDPRm</a>) capturing
-          time-varying representations of the associated <a>LDPR</a>. An <a>LDPCv</a> is both a <a>TimeMap</a> per
+          An <a>LDPCv</a> is both a <a>TimeMap</a> per
           Memento [[!RFC7089]] and an <a>LDPC</a>. As a <a>TimeMap</a> an <a>LDPCv</a> MUST conform to the
           specification for such resources in [[!RFC7089]]. An implementation MUST indicate <a>TimeMap</a> in the
-          same way it indicates the Container interaction model of the resource via HTTP headers. An <a>LDPCv</a>
-          MUST respond to <code>GET Accept: application/link-format</code> as indicated in [[!RFC7089]]
-          <a href='https://tools.ietf.org/html/rfc7089#section-5'>section 5</a> and specified in [[!RFC6690]]
-          <a href='https://tools.ietf.org/html/rfc6690#section-7.3'>section 7.3</a>.
+          same way it indicates the Container interaction model of the resource via HTTP headers.
         </p>
         <p>
           An implementation MUST NOT allow the creation of an <a>LDPCv</a> that is <a>LDP-contained</a> by its

--- a/index.html
+++ b/index.html
@@ -617,6 +617,7 @@
           A versioned resource (<a>LDPRv</a>) provides a <a>TimeGate</a> interaction model as detailed in the
           Memento specification [[RFC7089]]. It otherwise follows the [[!LDP]] specification, the
           <a href="#resource-management"></a> requirements, and the additional behaviors below.
+        </p>
 
         <section id="LDPRv-get">
           <h2>HTTP GET</h2>

--- a/index.html
+++ b/index.html
@@ -613,14 +613,10 @@
       </p>
       <section id="LDPRv">
         <h2>Versioned Resources (<a>LDPRv</a>)</h2>
-        <section id="LDPRv-general">
-          <h2>General</h2>
-          <p>
-            A versioned resource (<a>LDPRv</a>) provides a <a>TimeGate</a> interaction model as detailed in the
-            Memento specification [[RFC7089]]. It otherwise follows the [[!LDP]] specification, the
-            <a href="#resource-management"></a> requirements, and the additional behaviors below.
-          </p>
-        </section>
+        <p>
+          A versioned resource (<a>LDPRv</a>) provides a <a>TimeGate</a> interaction model as detailed in the
+          Memento specification [[RFC7089]]. It otherwise follows the [[!LDP]] specification, the
+          <a href="#resource-management"></a> requirements, and the additional behaviors below.
 
         <section id="LDPRv-get">
           <h2>HTTP GET</h2>
@@ -669,16 +665,13 @@
 
       <section id="LDPRm">
         <h2>Version Resources (<a>LDPRm</a>)</h2>
-        <section id="LDPRm-general">
-          <h2>General</h2>
-          <p>
-            When an <a>LDPR</a> is created with a <code>Link: rel="type"</code> header
-            specifying type <code>http://mementoweb.org/ns#OriginalResource</code>
-            to indicate versioning, it is created as both an <a>LDPRv</a> and a Memento: an
-            <a>LDPRm</a>. An <a>LDPRm</a> MAY be deleted; however,
-            it MUST NOT be modified once created.
-          </p>
-        </section>
+        <p>
+          When an <a>LDPR</a> is created with a <code>Link: rel="type"</code> header
+          specifying type <code>http://mementoweb.org/ns#OriginalResource</code>
+          to indicate versioning, it is created as both an <a>LDPRv</a> and a Memento: an
+          <a>LDPRm</a>. An <a>LDPRm</a> MAY be deleted; however,
+          it MUST NOT be modified once created.
+        </p>
 
         <section id="LDPRm-delete">
           <h2>HTTP DELETE</h2>
@@ -741,31 +734,28 @@
 
       <section id="LDPCv">
         <h2>Version Containers (<a>LDPCv</a>)</h2>
-        <section id="LDPCv-general">
-          <h2>General</h2>
-          <p>
-            When an <a>LDPR</a> is created with a <code>Link: rel="type"</code> header
-            specifying type <code>http://mementoweb.org/ns#OriginalResource</code>
-            to indicate versioning, a version container
-            (<a>LDPCv</a>) MUST be created that contains Memento-identified resources (<a>LDPRm</a>) capturing
-            time-varying representations of the associated <a>LDPR</a>. An <a>LDPCv</a> is both a <a>TimeMap</a> per
-            Memento [[!RFC7089]] and an <a>LDPC</a>. As a <a>TimeMap</a> an <a>LDPCv</a> MUST conform to the
-            specification for such resources in [[!RFC7089]]. An implementation MUST indicate <a>TimeMap</a> in the
-            same way it indicates the Container interaction model of the resource via HTTP headers. An <a>LDPCv</a>
-            MUST respond to <code>GET Accept: application/link-format</code> as indicated in [[!RFC7089]]
-            <a href='https://tools.ietf.org/html/rfc7089#section-5'>section 5</a> and specified in [[!RFC6690]]
-            <a href='https://tools.ietf.org/html/rfc6690#section-7.3'>section 7.3</a>.
-          </p>
-          <p>
-            An implementation MUST NOT allow the creation of an <a>LDPCv</a> that is <a>LDP-contained</a> by its
-            associated <a>LDPRv</a>.
-          </p>
-          <blockquote class="informative">
-            Non-normative note: The <code>application/link-format</code> representation of an <a>LDPCv</a> is not
-            required to include all statements in the <a>LDPCv</a> graph, only those required by <a>TimeMap</a>
-            behaviors.
-          </blockquote>
-        </section>
+        <p>
+          When an <a>LDPR</a> is created with a <code>Link: rel="type"</code> header
+          specifying type <code>http://mementoweb.org/ns#OriginalResource</code>
+          to indicate versioning, a version container
+          (<a>LDPCv</a>) MUST be created that contains Memento-identified resources (<a>LDPRm</a>) capturing
+          time-varying representations of the associated <a>LDPR</a>. An <a>LDPCv</a> is both a <a>TimeMap</a> per
+          Memento [[!RFC7089]] and an <a>LDPC</a>. As a <a>TimeMap</a> an <a>LDPCv</a> MUST conform to the
+          specification for such resources in [[!RFC7089]]. An implementation MUST indicate <a>TimeMap</a> in the
+          same way it indicates the Container interaction model of the resource via HTTP headers. An <a>LDPCv</a>
+          MUST respond to <code>GET Accept: application/link-format</code> as indicated in [[!RFC7089]]
+          <a href='https://tools.ietf.org/html/rfc7089#section-5'>section 5</a> and specified in [[!RFC6690]]
+          <a href='https://tools.ietf.org/html/rfc6690#section-7.3'>section 7.3</a>.
+        </p>
+        <p>
+          An implementation MUST NOT allow the creation of an <a>LDPCv</a> that is <a>LDP-contained</a> by its
+          associated <a>LDPRv</a>.
+        </p>
+        <blockquote class="informative">
+          Non-normative note: The <code>application/link-format</code> representation of an <a>LDPCv</a> is not
+          required to include all statements in the <a>LDPCv</a> graph, only those required by <a>TimeMap</a>
+          behaviors.
+        </blockquote>
 
         <section id="ldpcvdelete">
           <h2>HTTP DELETE</h2>


### PR DESCRIPTION
We allow content at any level of the section hierarchy so it seems most consistent to get rid of all the "General" section headings under "Resource Versioning".