### PR TITLE
Add link to previous specification URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,6 @@
             async class='remove'></script>
     <script class='remove'>
       var respecConfig = {
-          prevRecURI:  "https://fedora.info/2017/06/30/spec/",
           specStatus: "unofficial",
           shortName:  "fedora-api",
           includePermalinks: true,
@@ -35,6 +34,14 @@
           wgURI:        "https://wiki.duraspace.org/display/FEDORAAPI/Fedora+Specification",
           wgPublicList: "https://groups.google.com/forum/#!forum/fedora-community",
           otherLinks: [{
+            key: "Previous version",
+            data: [
+                {
+                  value: "https://fedora.info/2017/06/30/spec/",
+                  href: "https://fedora.info/2017/06/30/spec/"
+                }
+              ]
+            },{
             key: "Contributors",
             data: [
                 {

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
             async class='remove'></script>
     <script class='remove'>
       var respecConfig = {
+          prevRecURI:  "https://fedora.info/2017/06/30/spec/",
           specStatus: "unofficial",
           shortName:  "fedora-api",
           includePermalinks: true,


### PR DESCRIPTION
* Note: https://github.com/w3c/respec/wiki/previousURI did not render

Resolves: https://github.com/fcrepo/fcrepo-specification/issues/303
