### PR TITLE
Fix link to https to avoid bad redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The goal of this specification is to define the behaviors of [Fedora](http://fedorarepository.org/) server
 implementations to facilitate interoperability with client applications.
 
-* [Latest Published Version](http://fedora.info/spec/)
+* [Latest Published Version](https://fedora.info/spec/)
 * [Editor's Draft](https://fcrepo.github.io/fcrepo-specification/)
 
 


### PR DESCRIPTION
We want https anyway but at present the redirect is broken:
```
> curl -I http://fedora.info/spec/
HTTP/1.1 302 Found
Date: Tue, 28 Nov 2017 02:38:17 GMT
Location: https://fedora.infospec/
```