### PR TITLE
Making location headers a MUST in post responses for ldpcv's

### DIFF
--- a/index.html
+++ b/index.html
@@ -827,8 +827,8 @@
           </p>
           <p>
             If an implementation does not support one or both of <code>POST</code> cases above, it MUST respond to 
-            such requests with a 4xx range status code and a link to an appropriate constraints document (see
-            [[!LDP]]<a href='https://www.w3.org/TR/ldp/#ldpr-gen-pubclireqs'> 4.2.1.6</a>).
+            such requests with a 4xx range status code and a link to an appropriate constraints document (see 
+            [[!LDP]]<a href='https://www.w3.org/TR/ldp/#ldpr-gen-pubclireqs'>4.2.1.6</a>).
           </p>
           <blockquote class="informative">
             Non-normative note: If an <a>LDPCv</a> does not <code>Allow: POST</code>, the constraints document indicated

--- a/index.html
+++ b/index.html
@@ -828,7 +828,7 @@
           <p>
             If an implementation does not support one or both of <code>POST</code> cases above, it MUST respond to 
             such requests with a 4xx range status code and a link to an appropriate constraints document (see 
-            [[!LDP]]<a href='https://www.w3.org/TR/ldp/#ldpr-gen-pubclireqs'>4.2.1.6</a>).
+            [[!LDP]] <a href='https://www.w3.org/TR/ldp/#ldpr-gen-pubclireqs'>4.2.1.6</a>).
           </p>
           <blockquote class="informative">
             Non-normative note: If an <a>LDPCv</a> does not <code>Allow: POST</code>, the constraints document indicated

--- a/index.html
+++ b/index.html
@@ -828,10 +828,7 @@
           <p>
             If an implementation does not support one or both of <code>POST</code> cases above, it MUST respond to 
             such requests with a 4xx range status code and a link to an appropriate constraints document (see
-            [[!LDP]]<a href='https://www.w3.org/TR/ldp/#ldpr-gen-pubclireqs'> 4.2.1.6</a>). As per [[!LDP]]
-            <a href='https://www.w3.org/TR/ldp/#h-ldpc-post-created201'> 5.2.3.1</a>, any resource
-            created via <code>POST</code>, in this case an <a>LDPRm</a>, MUST be advertised in the
-            <code>Location</code> response header.
+            [[!LDP]]<a href='https://www.w3.org/TR/ldp/#ldpr-gen-pubclireqs'> 4.2.1.6</a>).
           </p>
           <blockquote class="informative">
             Non-normative note: If an <a>LDPCv</a> does not <code>Allow: POST</code>, the constraints document indicated

--- a/index.html
+++ b/index.html
@@ -828,8 +828,9 @@
           <p>
             If an implementation does not support one or both of <code>POST</code> cases above, it MUST respond to 
             such requests with a 4xx range status code and a link to an appropriate constraints document (see
-            <a href='https://www.w3.org/TR/ldp/#ldpr-gen-pubclireqs'>LDP 4.2.1.6</a>). As per [[!LDP]], any resource
-            created via <code>POST</code>, in this case an <a>LDPRm</a>, SHOULD be advertised in the
+            [[!LDP]]<a href='https://www.w3.org/TR/ldp/#ldpr-gen-pubclireqs'> 4.2.1.6</a>). As per [[!LDP]]
+            <a href='https://www.w3.org/TR/ldp/#h-ldpc-post-created201'> 5.2.3.1</a>, any resource
+            created via <code>POST</code>, in this case an <a>LDPRm</a>, MUST be advertised in the
             <code>Location</code> response header.
           </p>
           <blockquote class="informative">


### PR DESCRIPTION
Resolves https://github.com/fcrepo/fcrepo-specification/issues/311

Strengthens Location headers in POST responses for LDPCv's from SHOULD to MUST.  Also touches up a nearby link.