### PR TITLE
Editorial change: Reordering of Authorization subsections

### DIFF
--- a/index.html
+++ b/index.html
@@ -935,19 +935,42 @@
           An <a>ACL</a> for a controlled resource on a conforming server MUST itself be an <a>LDP-RS</a>.
         </p>
       </section>
-      <section id="cross-domain-acls">
-        <h2>Cross-Domain ACLs</h2>
-        <blockquote class="informative">
-          Non-normative note:
-          Implementation of support for <a>ACL</a>s requires retrieval of one or more <a>ACL</a> resources.
-          Security implications should be considered if remote <a>ACL</a>s are supported.
-        </blockquote>
+      <section id="acl-representation">
+        <h2>ACL Representation and Interpretation</h2>
         <p>
-          Implementations MAY restrict support for <a>ACL</a>s to local resources. If an implementation chooses to
-          reject requests concerning remote <a>ACL</a>s, it MUST respond with a 4xx range status code and
-          MUST advertise the restriction with a <code>rel="http://www.w3.org/ns/ldp#constrainedBy"</code> link in
-          the <code>Link</code> response header.
+          ACL resources are represented as described in [[!SOLIDWEBAC]]
+          <a href="https://github.com/solid/web-access-control-spec#representation-format">Representation
+          Format</a>. Implementations MUST inspect the ACL RDF for authorizations. Authorizations are identified by
+          type definition triples of the form <code>authorization_N rdf:type acl:Authorization</code>, where
+          <code>authorization_N</code> is the URI of an authorization. Implementations MUST use only statements
+          associated with an authorization in the ACL RDF to determine access, except in the case of
+          <code>acl:agentGroup</code> statements where the group listing document is dereferenced. The
+          authorizations MUST be examined to see whether they grant the requested access to the controlled
+          resource. If none of the authorizations grant the requested access then the request MUST be denied.
         </p>
+        <blockquote class="informative">
+          <p>
+            Non-normative note:
+            Implementations may set default access controls for all resources by including an ACL for the root
+            container with an authorization that applies to access by any agent (<code>acl:agentClass
+            foaf:Agent</code>), applies to any resource (<code>acl:accessToClass ldp:Resource</code>), and is defined
+            to be inherited (<code>acl:default</code>). The example below grants read access (<code>acl:mode
+            acl:Read</code>) but any combination of modes may be specified.
+          </p>
+        </blockquote>
+        <div class="example">
+<pre># ACL for https://example.org/root/ in Turtle
+@prefix acl: &lt;http://www.w3.org/ns/auth/acl#&gt; .
+@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .
+@prefix ldp: &lt;http://www.w3.org/ns/ldp#&gt; .
+
+&lt;#authorization_1&gt; a acl:Authorization ;
+    acl:agentClass foaf:Agent ;
+    acl:accessToClass ldp:Resource ;
+    acl:default &lt;https://example.org/root/&gt; ;
+    acl:mode acl:Read .
+</pre>
+        </div>
       </section>
       <section id="link-rel-acl">
         <h2>ACLs are discoverable via Link Headers</h2>
@@ -967,6 +990,50 @@
             support <a href="#http-put-create">creation with HTTP <code>PUT</code></a> for individual <a>ACL</a>s.
           </p>
         </blockquote>
+      </section>
+      <section id="link-acl-on-create">
+        <h2>ACL linking on resource creation</h2>
+        <p>
+          A client HTTP <code>POST</code> or <code>PUT</code> request to create a new <a>LDPR</a> MAY include a
+          <code>rel="acl"</code> link in the <code>Link</code> header referencing an existing <a>LDP-RS</a> to use as
+          the <a>ACL</a> for the new <a>LDPR</a>. The server MUST reject the request and respond with a 4xx or 5xx
+          range status code, such as 409 (Conflict) if it isn't able to create the <a>LDPR</a> with the specified
+          <a>LDP-RS</a> as the <a>ACL</a>. In that response, the restrictions causing the request to fail MUST be
+          described in a resource indicated by a <code>rel="http://www.w3.org/ns/ldp#constrainedBy"</code> link in
+          the <code>Link</code> response header, following the pattern of [[!LDP]]
+          <a href='https://www.w3.org/TR/ldp/#ldpr-gen-pubclireqs'>4.2.1.6</a>.
+        <p>
+      </section>
+      <section id="cross-domain-acls">
+        <h2>Cross-Domain ACLs</h2>
+        <blockquote class="informative">
+          Non-normative note:
+          Implementation of support for <a>ACL</a>s requires retrieval of one or more <a>ACL</a> resources.
+          Security implications should be considered if remote <a>ACL</a>s are supported.
+        </blockquote>
+        <p>
+          Implementations MAY restrict support for <a>ACL</a>s to local resources. If an implementation chooses to
+          reject requests concerning remote <a>ACL</a>s, it MUST respond with a 4xx range status code and
+          MUST advertise the restriction with a <code>rel="http://www.w3.org/ns/ldp#constrainedBy"</code> link in
+          the <code>Link</code> response header.
+        </p>
+      </section>
+      <section id="cross-domain-groups">
+        <h2>Cross-Domain Group Listings</h2>
+        <blockquote class="informative">
+          Non-normative note:
+          Implementation of support for [[!SOLIDWEBAC]]
+          <a href="https://github.com/solid/web-access-control-spec#groups-of-agents">groups of agents</a> requires
+          retrieval of one or more Group Listing documents. Security implications should be considered if remote Group
+          Listing documents are supported.
+        </blockquote>
+        <p>
+          Implementations MAY restrict support for [[!SOLIDWEBAC]]
+          <a href="https://github.com/solid/web-access-control-spec#groups-of-agents">groups of agents</a> to local
+          Group Listing documents. If an implementation chooses to reject requests concerning remote Group Listings,
+          it MUST respond with a 4xx range status code and MUST advertise the restriction with a
+          <code>rel="http://www.w3.org/ns/ldp#constrainedBy"</code> link in the <code>Link</code> response header.
+        </p>
       </section>
       <section id="append-mode">
         <h2>Append Mode</h2>
@@ -1040,95 +1107,7 @@
           </p>
         </blockquote>
       </section>
-      <section id="acl-representation">
-        <h2>ACL Representation and Interpretation</h2>
-        <p>
-          ACL resources are represented as described in [[!SOLIDWEBAC]]
-          <a href="https://github.com/solid/web-access-control-spec#representation-format">Representation
-          Format</a>. Implementations MUST inspect the ACL RDF for authorizations. Authorizations are identified by
-          type definition triples of the form <code>authorization_N rdf:type acl:Authorization</code>, where
-          <code>authorization_N</code> is the URI of an authorization. Implementations MUST use only statements
-          associated with an authorization in the ACL RDF to determine access, except in the case of
-          <code>acl:agentGroup</code> statements where the group listing document is dereferenced. The
-          authorizations MUST be examined to see whether they grant the requested access to the controlled
-          resource. If none of the authorizations grant the requested access then the request MUST be denied.
-        </p>
-        <blockquote class="informative">
-          <p>
-            Non-normative note:
-            Implementations may set default access controls for all resources by including an ACL for the root
-            container with an authorization that applies to access by any agent (<code>acl:agentClass
-            foaf:Agent</code>), applies to any resource (<code>acl:accessToClass ldp:Resource</code>), and is defined
-            to be inherited (<code>acl:default</code>). The example below grants read access (<code>acl:mode
-            acl:Read</code>) but any combination of modes may be specified.
-          </p>
-        </blockquote>
-        <div class="example">
-<pre># ACL for https://example.org/root/ in Turtle
-@prefix acl: &lt;http://www.w3.org/ns/auth/acl#&gt; .
-@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .
-@prefix ldp: &lt;http://www.w3.org/ns/ldp#&gt; .
-
-&lt;#authorization_1&gt; a acl:Authorization ;
-    acl:agentClass foaf:Agent ;
-    acl:accessToClass ldp:Resource ;
-    acl:default &lt;https://example.org/root/&gt; ;
-    acl:mode acl:Read .
-</pre>
-        </div>
-      </section>
-      <section id="cross-domain-groups">
-        <h2>Cross-Domain Group Listings</h2>
-        <blockquote class="informative">
-          Non-normative note:
-          Implementation of support for [[!SOLIDWEBAC]] 
-          <a href="https://github.com/solid/web-access-control-spec#groups-of-agents">groups of agents</a> requires
-          retrieval of one or more Group Listing documents. Security implications should be considered if remote Group
-          Listing documents are supported.
-        </blockquote>
-        <p>
-          Implementations MAY restrict support for [[!SOLIDWEBAC]]
-          <a href="https://github.com/solid/web-access-control-spec#groups-of-agents">groups of agents</a> to local
-          Group Listing documents. If an implementation chooses to reject requests concerning remote Group Listings,
-          it MUST respond with a 4xx range status code and MUST advertise the restriction with a
-          <code>rel="http://www.w3.org/ns/ldp#constrainedBy"</code> link in the <code>Link</code> response header.
-        </p>
-      </section>
-      <section id="webids">
-        <h2>WebIDs</h2>
-        <blockquote class="informative">
-          <p>
-            Non-normative note:
-            The [[!SOLIDWEBAC]] <a href="https://github.com/solid/web-access-control-spec#overview">overview</a>
-            mentions parenthetically that user and group identifiers should be WebIDs. For the purposes of performing
-            authorization, the essential requirements are:
-          </p>
-          <ul>
-            <li>
-              User and group identifiers must be IRIs.
-            </li>
-            <li>
-              Group IRIs must be dereferencable as RDF, and must link to member IRIs using the
-              <code>vcard:hasMember</code> predicate.
-            </li>
-          </ul>
-        </blockquote>
-      </section>
-      <section id="link-acl-on-create">
-        <h2>ACL linking on resource creation</h2>
-        <p>
-          A client HTTP <code>POST</code> or <code>PUT</code> request to create a new <a>LDPR</a> MAY include a
-          <code>rel="acl"</code> link in the <code>Link</code> header referencing an existing <a>LDP-RS</a> to use as
-          the <a>ACL</a> for the new <a>LDPR</a>. The server MUST reject the request and respond with a 4xx or 5xx
-          range status code, such as 409 (Conflict) if it isn't able to create the <a>LDPR</a> with the specified
-          <a>LDP-RS</a> as the <a>ACL</a>. In that response, the restrictions causing the request to fail MUST be
-          described in a resource indicated by a <code>rel="http://www.w3.org/ns/ldp#constrainedBy"</code> link in
-          the <code>Link</code> response header, following the pattern of [[!LDP]]
-          <a href='https://www.w3.org/TR/ldp/#ldpr-gen-pubclireqs'>4.2.1.6</a>.
-        <p>
-      </section>
     </section>
-
     <section id="notifications">
       <h2>Notifications</h2>
       <section id="notifications-intro">


### PR DESCRIPTION
This update does not introduce any changes to the wording...
 but is instead limited to reordering subsections of section 5.

Relative to the previous order, this update assigns the new order:
5.1
5.3
5.9
5.2
5.7
5.4
5.5
5.6
5.8

Resolves: https://github.com/fcrepo/fcrepo-specification/issues/313