### PR TITLE
relabel 'What is Fixity?' as 'Introduction'

### DIFF
--- a/index.html
+++ b/index.html
@@ -1362,6 +1362,7 @@ Location: http://example.org/document</pre>
     </section>
 
     <section id="binary-fixity">
+      <h2>Binary Resource Fixity</h2>
       <section id="fixity-introduction">
         <blockquote class="informative">
           <p>
@@ -1392,7 +1393,7 @@ Location: http://example.org/document</pre>
         </blockquote>
       </section>
       <section id="transmission-fixity">
-        <h2>Transmission Fixity</h2>
+        <h3>Transmission Fixity</h3>
         <blockquote class="informative">
           Non-normative note:
           Transmission fixity may be verified by including a <code>Digest</code> header (defined in [[RFC3230]]) in
@@ -1400,7 +1401,7 @@ Location: http://example.org/document</pre>
         </blockquote>
       </section>
       <section id="persistence-fixity">
-        <h2>Persistence Fixity</h2>
+        <h3>Persistence Fixity</h3>
         <blockquote class="informative">
           Non-normative note:
           A client may retrieve the checksum of an <a>LDP-NR</a> by performing a <code>HEAD</code> or <code>GET</code>

--- a/index.html
+++ b/index.html
@@ -1363,35 +1363,33 @@ Location: http://example.org/document</pre>
 
     <section id="binary-fixity">
       <h2>Binary Resource Fixity</h2>
-      <section id="fixity-introduction">
-        <blockquote class="informative">
-          <p>
-            Non-normative note:
-            For the purposes of the following specification, a fixity result is an extract or summary of some
-            <a>LDP-NR</a> made according to some explicit procedure. Fixity results are taken for the purpose of
-            comparing different fixity results for the same resource over time, to ensure a continuity of that
-            resource's identity according to the particular procedure used. Examples might include:
-          </p>
-          <ul>
-            <li>
-              Checksums like MD5 or SHA1, often used for digital images.
-            </li>
-            <li>
-              <a href="https://www.w3.org/TR/xmldsig-core/">XML Signatures</a>
-            </li>
-            <li>
-              Per-segment results
-              <a href="http://dericed.com/papers/reconsidering-the-checksum-for-audiovisual-preservation/">as used for
-              time-based media</a>
-            </li>
-          </ul>
-          <p>
-            This specification describes two fixity verification mechanisms: firstly, as part of content transmission,
-            to guard against faults in transmission, and secondly, by comparison to a known or proffered digest value,
-            to monitor for faults in persistence.
-          </p>
-        </blockquote>
-      </section>
+      <blockquote class="informative">
+        <p>
+          Non-normative note:
+          For the purposes of the following specification, a fixity result is an extract or summary of some
+          <a>LDP-NR</a> made according to some explicit procedure. Fixity results are taken for the purpose of
+          comparing different fixity results for the same resource over time, to ensure a continuity of that
+          resource's identity according to the particular procedure used. Examples might include:
+        </p>
+        <ul>
+          <li>
+            Checksums like MD5 or SHA1, often used for digital images.
+          </li>
+          <li>
+            <a href="https://www.w3.org/TR/xmldsig-core/">XML Signatures</a>
+          </li>
+          <li>
+            Per-segment results
+            <a href="http://dericed.com/papers/reconsidering-the-checksum-for-audiovisual-preservation/">as used for
+            time-based media</a>
+          </li>
+        </ul>
+        <p>
+          This specification describes two fixity verification mechanisms: firstly, as part of content transmission,
+          to guard against faults in transmission, and secondly, by comparison to a known or proffered digest value,
+          to monitor for faults in persistence.
+        </p>
+      </blockquote>
       <section id="transmission-fixity">
         <h3>Transmission Fixity</h3>
         <blockquote class="informative">

--- a/index.html
+++ b/index.html
@@ -1363,7 +1363,6 @@ Location: http://example.org/document</pre>
 
     <section id="binary-fixity">
       <section id="fixity-introduction">
-        <h2>What is fixity?</h2>
         <blockquote class="informative">
           <p>
             Non-normative note:

--- a/index.html
+++ b/index.html
@@ -1362,8 +1362,7 @@ Location: http://example.org/document</pre>
     </section>
 
     <section id="binary-fixity">
-      <h2>Binary Resource Fixity</h2>
-      <section id="what-is-fixity">
+      <section id="fixity-introduction">
         <h2>What is fixity?</h2>
         <blockquote class="informative">
           <p>


### PR DESCRIPTION
use "clients" instead of "a client" to parallel "implementations" language
fixes #360