### PR TITLE
Editorial clean-up (section 5)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1111,7 +1111,8 @@ Location: http://example.org/document</pre>
         <h2>Cross-Domain Group Listings</h2>
         <blockquote class="informative">
           Non-normative note:
-          [[!SOLIDWEBAC]] <a href="https://github.com/solid/web-access-control-spec#groups-of-agents">groups of agents</a>
+          [[!SOLIDWEBAC]]
+          <a href="https://github.com/solid/web-access-control-spec#groups-of-agents">groups of agents</a>
           requires retrieval of one or more Group Listing documents. Security implications should be considered if remote
           Group Listing documents are supported.
         </blockquote>

--- a/index.html
+++ b/index.html
@@ -1113,8 +1113,8 @@ Location: http://example.org/document</pre>
           Non-normative note:
           [[!SOLIDWEBAC]]
           <a href="https://github.com/solid/web-access-control-spec#groups-of-agents">groups of agents</a>
-          requires retrieval of one or more Group Listing documents. Security implications should be considered if remote
-          Group Listing documents are supported.
+          requires retrieval of one or more Group Listing documents. Security implications should be considered if
+          remote Group Listing documents are supported.
         </blockquote>
         <p>
           Implementations MAY restrict support for [[!SOLIDWEBAC]]

--- a/index.html
+++ b/index.html
@@ -1097,7 +1097,7 @@ Location: http://example.org/document</pre>
         <h2>Cross-Domain ACLs</h2>
         <blockquote class="informative">
           Non-normative note:
-          Implementation of support for <a>ACL</a>s requires retrieval of one or more <a>ACL</a> resources.
+          <a>ACL</a> implementations may require retrieval of one or more <a>ACL</a> resources.
           Security implications should be considered if remote <a>ACL</a>s are supported.
         </blockquote>
         <p>
@@ -1111,10 +1111,9 @@ Location: http://example.org/document</pre>
         <h2>Cross-Domain Group Listings</h2>
         <blockquote class="informative">
           Non-normative note:
-          Implementation of support for [[!SOLIDWEBAC]]
-          <a href="https://github.com/solid/web-access-control-spec#groups-of-agents">groups of agents</a> requires
-          retrieval of one or more Group Listing documents. Security implications should be considered if remote Group
-          Listing documents are supported.
+          [[!SOLIDWEBAC]] <a href="https://github.com/solid/web-access-control-spec#groups-of-agents">groups of agents</a>
+          requires retrieval of one or more Group Listing documents. Security implications should be considered if remote
+          Group Listing documents are supported.
         </blockquote>
         <p>
           Implementations MAY restrict support for [[!SOLIDWEBAC]]
@@ -1135,7 +1134,8 @@ Location: http://example.org/document</pre>
         <section id="append-ldprs">
           <h3>LDP-RS</h3>
           <p>
-            When a client is allowed to perform <code>acl:Append</code> operations on an <a>LDP-RS</a>:
+            When a client is allowed to perform <code>acl:Append</code> but not <code>acl:Write</code> operations on an
+            <a>LDP-RS</a>:
           </p>
           <ul>
             <li>A <code>DELETE</code> request MUST be denied</li>
@@ -1150,13 +1150,15 @@ Location: http://example.org/document</pre>
           <h3>LDPC</h3>
           <p>
             In addition to requirements in <a href='#append-ldprs'></a>, when a client is allowed to perform
-            <code>acl:Append</code> operations on an <a>LDPC</a>, a <code>POST</code> request MUST be allowed.
+            <code>acl:Append</code> but not <code>acl:Write</code> operations on an <a>LDPC</a>, a <code>POST</code>
+            request MUST be allowed.
           </p>
         </section>
         <section id="append-ldpnr">
           <h3>LDP-NR</h3>
           <p>
-            When a client is allowed to perform <code>acl:Append</code> operations on an <a>LDP-NR</a>:
+            When a client is allowed to perform <code>acl:Append</code> but not <code>acl:Write</code> operations on an
+            <a>LDP-NR</a>:
           </p>
           <ul>
             <li>All <code>DELETE</code>, <code>POST</code>, and <code>PUT</code> requests MUST be denied</li>

--- a/index.html
+++ b/index.html
@@ -1113,7 +1113,7 @@ Location: http://example.org/document</pre>
           Non-normative note:
           [[!SOLIDWEBAC]]
           <a href="https://github.com/solid/web-access-control-spec#groups-of-agents">groups of agents</a>
-          requires retrieval of one or more Group Listing documents. Security implications should be considered if
+          require retrieval of one or more Group Listing documents. Security implications should be considered if
           remote Group Listing documents are supported.
         </blockquote>
         <p>


### PR DESCRIPTION
* Remove wording: 'Implementation of support'
* Add 'but not acl:Write' when detailing acl:Append expectations

Resolves part of: https://github.com/fcrepo/fcrepo-specification/issues/358