### PR TITLE
External content security considerations

### DIFF
--- a/index.html
+++ b/index.html
@@ -564,6 +564,11 @@
 
       <section id="external-content">
         <h3>External Binary Content</h3>
+        <blockquote id="external-content-security-considerations" class="informative">
+          Non-normative note: External content features expose resources outside of the repository,
+          and careful consideration should be given by implementations to prevent malicious requests from gaining
+          access to sensitive information.
+        </blockquote>
         <blockquote id="external-content-variability" class="informative">
           Non-normative note: Variability among client types and locations may mean that <a>LDP-NR</a> content is
           addressed in ways that are external to the Fedora server but not resolvable by all clients. This specification
@@ -575,11 +580,6 @@
           other URI schemes for addressing external content per the requirements for advertisement and rejection
           specified here. The <code>handling</code> attribute is introduced to specify the handling of the external
           content: either copying, redirecting, or proxying.
-        </blockquote>
-        <blockquote id="external-content-security-considerations" class="informative">
-          Non-normative note: External content features expose resources outside of the repository tree to users,
-          and careful consideration should be given by implementors to prevent malicious requests from gaining
-          access to sensitive information.
         </blockquote>
         <div class="example">
 <pre>Link: &lt;http://example.org/some/content&gt;;
@@ -1452,13 +1452,13 @@ Location: http://example.org/document</pre>
       </p>
       <ul>
         <li>
-          <a href="#external-content-security-considerations">3.9 External Binary Content</a>
+          <a href="#external-content"></a>
         </li>
         <li>
-          <a href="#cross-domain-acls-security-considerations">5.5 Cross-Domain ACLs</a>
+          <a href="#cross-domain-acls"></a>
         </li>
         <li>
-          <a href="#cross-domain-groups-security-considerations">5.6 Cross-Domain Group Listings</a>
+          <a href="#cross-domain-groups"></a>
         </li>
       </ul>
     </section>

--- a/index.html
+++ b/index.html
@@ -576,6 +576,11 @@
           specified here. The <code>handling</code> attribute is introduced to specify the handling of the external
           content: either copying, redirecting, or proxying.
         </blockquote>
+        <blockquote id="external-content-security-considerations" class="informative">
+          Non-normative note: External content features expose resources outside of the repository tree to users,
+          and careful consideration should be given by implementors to prevent malicious requests from gaining
+          access to sensitive information.
+        </blockquote>
         <div class="example">
 <pre>Link: &lt;http://example.org/some/content&gt;;
       rel="http://fedora.info/definitions/fcrepo#ExternalContent";
@@ -1091,7 +1096,7 @@ Location: http://example.org/document</pre>
       </section>
       <section id="cross-domain-acls">
         <h2>Cross-Domain ACLs</h2>
-        <blockquote class="informative">
+        <blockquote id="cross-domain-acls-security-considerations" class="informative">
           Non-normative note:
           <a>ACL</a> implementations may require retrieval of one or more <a>ACL</a> resources.
           Security implications should be considered if remote <a>ACL</a>s are supported.
@@ -1105,7 +1110,7 @@ Location: http://example.org/document</pre>
       </section>
       <section id="cross-domain-groups">
         <h2>Cross-Domain Group Listings</h2>
-        <blockquote class="informative">
+        <blockquote id="cross-domain-groups-security-considerations" class="informative">
           Non-normative note:
           [[!SOLIDWEBAC]]
           <a href="https://github.com/solid/web-access-control-spec#groups-of-agents">groups of agents</a>
@@ -1431,6 +1436,21 @@ Location: http://example.org/document</pre>
         <li>
           [[!activitystreams-core]] <a href="https://www.w3.org/TR/activitystreams-core/#security-considerations">7.
           Security Considerations</a>
+        </li>
+      </ul>
+      <p>
+        Security considerations for features introduced in this specification can be located in their individual
+        sections:
+      </p>
+      <ul>
+        <li>
+          <a href="#external-content-security-considerations">3.9 External Binary Content</a>
+        </li>
+        <li>
+          <a href="#cross-domain-acls-security-considerations">5.5 Cross-Domain ACLs</a>
+        </li>
+        <li>
+          <a href="#cross-domain-groups-security-considerations">5.6 Cross-Domain Group Listings</a>
         </li>
       </ul>
     </section>


### PR DESCRIPTION
Resolves https://github.com/fcrepo/fcrepo-specification/issues/391

Adds a security considerations section to section `3.9 External Content`.

Also links to security considerations within the specification in section `9. Security Considerations`.